### PR TITLE
Adding tests for LHS violations.

### DIFF
--- a/examples/plot_by_depolarizing_noise.py
+++ b/examples/plot_by_depolarizing_noise.py
@@ -3,19 +3,20 @@ import qiskit
 from qiskit.providers import fake_provider
 from qiskit_aer.noise import NoiseModel, depolarizing_error
 
-from wigners_friend.config import (ANGLES, BETA)
+from wigners_friend.config import ANGLES, BETA
 from wigners_friend.stats import compute_inequalities
 from wigners_friend.utils import generate_all_experiments
 from wigners_friend.plots import plot_friend_size_vs_violation, plot_noise_levels_vs_violation
 
 
 BACKEND = qiskit.Aer.get_backend("aer_simulator")
-SHOTS = 1000
+SHOTS = 10_000
 
 violations = []
 noise_levels = []
 friend_size = 1
-for noise_level in [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01]:
+# Ranges from 0% -> 1% of noise.
+for noise_level in np.linspace(0, 0.1, 11):
     NOISE_MODEL = NoiseModel()
 
     error = depolarizing_error(noise_level, 1)

--- a/examples/plot_by_friend_size.py
+++ b/examples/plot_by_friend_size.py
@@ -3,7 +3,7 @@ import qiskit
 from qiskit.providers import fake_provider
 from qiskit_aer.noise import NoiseModel, depolarizing_error
 
-from wigners_friend.config import (ANGLES, BETA)
+from wigners_friend.config import ANGLES, BETA
 from wigners_friend.stats import compute_inequalities
 from wigners_friend.utils import generate_all_experiments
 from wigners_friend.plots import plot_friend_size_vs_violation, plot_noise_levels_vs_violation

--- a/examples/run.py
+++ b/examples/run.py
@@ -1,7 +1,0 @@
-from wigners_friend.config import (ANGLES, BETA, BACKEND, NOISE_MODEL, SHOTS)
-from wigners_friend.stats import compute_inequalities
-from wigners_friend.utils import generate_all_experiments
-
-
-results = generate_all_experiments(backend=BACKEND, noise_model=NOISE_MODEL, shots=SHOTS, angles=ANGLES, beta=BETA)
-print(compute_inequalities(results, verbose=True))

--- a/examples/run_hardware.py
+++ b/examples/run_hardware.py
@@ -1,0 +1,31 @@
+import numpy as np
+import qiskit
+
+from wigners_friend.config import ANGLES, BETA
+from wigners_friend.stats import compute_inequalities
+from wigners_friend.utils import generate_all_experiments
+
+
+IBM_PROVIDER_TOKEN = os.getenv("IBM_PROVIDER_TOKEN")
+
+# Save an IBM Quantum account and set it as your default account.
+QiskitRuntimeService.save_account(channel="ibm_quantum", token=IBM_PROVIDER_TOKEN, set_as_default=True, overwrite=True)
+
+# Load saved credentials
+service = QiskitRuntimeService()
+BACKEND = service.backend("ibmq_kolkata")
+NOISE_MODEL = NoiseModel.from_backend(BACKEND)
+SHOTS = 10_000
+friend_size = 1
+
+results = generate_all_experiments(
+    backend=BACKEND,
+    noise_model=NOISE_MODEL,
+    shots=SHOTS,
+    angles=ANGLES,
+    beta=BETA,
+    charlie_size=friend_size,
+    debbie_size=friend_size
+)
+violations = compute_inequalities(results)
+print(violations)

--- a/examples/run_noisy_simulator.py
+++ b/examples/run_noisy_simulator.py
@@ -1,0 +1,24 @@
+import numpy as np
+import qiskit
+
+from wigners_friend.config import ANGLES, BETA
+from wigners_friend.stats import compute_inequalities
+from wigners_friend.utils import generate_all_experiments
+
+
+BACKEND = mock.FakeKolkata()
+NOISE_MODEL = NoiseModel.from_backend(BACKEND)
+SHOTS = 10_000
+friend_size = 1
+
+results = generate_all_experiments(
+    backend=BACKEND,
+    noise_model=NOISE_MODEL,
+    shots=SHOTS,
+    angles=ANGLES,
+    beta=BETA,
+    charlie_size=friend_size,
+    debbie_size=friend_size
+)
+violations = compute_inequalities(results)
+print(violations)

--- a/examples/run_noisy_simulator.py
+++ b/examples/run_noisy_simulator.py
@@ -1,5 +1,6 @@
 import numpy as np
 import qiskit
+from qiskit.test import mock
 
 from wigners_friend.config import ANGLES, BETA
 from wigners_friend.stats import compute_inequalities

--- a/examples/run_simulator.py
+++ b/examples/run_simulator.py
@@ -1,0 +1,24 @@
+import numpy as np
+import qiskit
+
+from wigners_friend.config import ANGLES, BETA
+from wigners_friend.stats import compute_inequalities
+from wigners_friend.utils import generate_all_experiments
+
+
+BACKEND = qiskit.Aer.get_backend("aer_simulator")
+SHOTS = 100_000
+NOISE_MODEL = None
+friend_size = 1
+
+results = generate_all_experiments(
+    backend=BACKEND,
+    noise_model=NOISE_MODEL,
+    shots=SHOTS,
+    angles=ANGLES,
+    beta=BETA,
+    charlie_size=friend_size,
+    debbie_size=friend_size
+)
+violations = compute_inequalities(results)
+print(violations)

--- a/tests/test_violation_lhs.py
+++ b/tests/test_violation_lhs.py
@@ -1,0 +1,45 @@
+# Known LHS violation values. Extracted from Excel file from `data/`
+import numpy as np
+import qiskit
+import pytest
+
+from wigners_friend.config import ANGLES, BETA
+from wigners_friend.stats import compute_inequalities
+from wigners_friend.utils import generate_all_experiments
+
+
+lhs_violation_vals = {
+    "mu": {
+        "1": {
+            "lf": 0.57028,
+            "I3322": 0.299348,
+            "brukner": 0.124336,
+            "semi_brukner": 0.380364,
+            "bell_non_lf": 0.59116
+        }
+    }
+}
+
+
+def test_violation_lhs():
+    BACKEND = qiskit.Aer.get_backend("aer_simulator")
+    SHOTS = 100_000
+    NOISE_MODEL = None
+    friend_size = 1
+
+    results = generate_all_experiments(
+        backend=BACKEND,
+        noise_model=NOISE_MODEL,
+        shots=SHOTS,
+        angles=ANGLES,
+        beta=BETA,
+        charlie_size=friend_size,
+        debbie_size=friend_size
+    )
+    violations = compute_inequalities(results)
+
+    assert np.isclose(violations["lf"], lhs_violation_vals["mu"]["1"]["lf"], atol=0.1)
+    assert np.isclose(violations["I3322"], lhs_violation_vals["mu"]["1"]["I3322"], atol=0.1)
+    assert np.isclose(violations["brukner"], lhs_violation_vals["mu"]["1"]["brukner"], atol=0.1)
+    assert np.isclose(violations["semi_brukner"], lhs_violation_vals["mu"]["1"]["semi_brukner"], atol=0.1)
+    assert np.isclose(violations["bell_non_lf"], lhs_violation_vals["mu"]["1"]["bell_non_lf"], atol=0.1)

--- a/wigners_friend/config.py
+++ b/wigners_friend/config.py
@@ -10,33 +10,6 @@ from qiskit_aer.noise import NoiseModel
 from wigners_friend.observer import Observer
 from wigners_friend.setting import Setting
 
-####################################
-# * Noise model and hardware.      *
-####################################
-USE_HARDWARE = False
-USE_SIMULATOR = True
-USE_NOISY_SIMULATOR = False
-
-if USE_HARDWARE:
-    IBM_PROVIDER_TOKEN = os.getenv("IBM_PROVIDER_TOKEN")
-    # Save an IBM Quantum account and set it as your default account.
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token=IBM_PROVIDER_TOKEN, set_as_default=True, overwrite=True)
-    
-    # Load saved credentials
-    service = QiskitRuntimeService()
-    BACKEND = service.backend("ibmq_kolkata")
-    NOISE_MODEL = NoiseModel.from_backend(BACKEND)
-
-if USE_SIMULATOR:
-    BACKEND = qiskit.Aer.get_backend("aer_simulator")
-    NOISE_MODEL = None
-
-if USE_NOISY_SIMULATOR:
-    BACKEND = mock.FakeKolkata()
-    NOISE_MODEL = NoiseModel.from_backend(BACKEND)
-
-# Sampling shots to run.
-SHOTS = 100_000
 
 ####################################
 # * EWFS configurational settings. *


### PR DESCRIPTION
1. Adding tests for LHS violation values for `mu=1` in `tests/`
2. Taking out explicit `USE_HARDWARE`, etc. variables and instead making separate scripts for running on either a simulator, noisy simulator, or hardware. 
3. Adding some examples in `examples/` folder for running on sim, hardware, and noisy sim. 