### PR TITLE
add barrier to help with compiler optimizations

### DIFF
--- a/ewfs/ewfs.py
+++ b/ewfs/ewfs.py
@@ -141,6 +141,7 @@ def apply_setting(qc: QuantumCircuit,
 
     elif setting in [REVERSE_1, REVERSE_2]:
         if strategy == "majority_vote":
+            qc.barrier(observer, friend_qubits)
             cnot_ladder(qc, observer, friend_qubits[0], friend_size, reverse=True, internal_copy=True)
         elif strategy == "random":
             cnot_ladder_random(qc, observer, friend_qubits[0], friend_size)

--- a/ewfs/ewfs.py
+++ b/ewfs/ewfs.py
@@ -140,8 +140,8 @@ def apply_setting(qc: QuantumCircuit,
             qc.measure(friend_qubits[0] + random_offset, observer)
 
     elif setting in [REVERSE_1, REVERSE_2]:
+        qc.barrier(observer, friend_qubits)
         if strategy == "majority_vote":
-            qc.barrier(observer, friend_qubits)
             cnot_ladder(qc, observer, friend_qubits[0], friend_size, reverse=True, internal_copy=True)
         elif strategy == "random":
             cnot_ladder_random(qc, observer, friend_qubits[0], friend_size)


### PR DESCRIPTION
We do want compiler optimizations, like ucc and with qiskit, but we don't want to lose our unitary reversals. Luckily qiskit has a barrier function that we can use. See the issue here for more discussion: https://github.com/unitaryfund/ucc/issues/81

This PR implements a barrier when generating the EWFS circuits. 

Would it be worth re-running some hardware data to see if things improve with this barrier and these compilers at some point? How did you handle the barrier in Nexus? @vprusso @FarLab ?