### PR TITLE
reduce sampling in tests to speed them up

### DIFF
--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -21,7 +21,7 @@ from ewfs.experiment import run_experiment
 )
 def test_random_strategy(backend, charlie_sizes, debbie_sizes, settings):
     results = run_experiment(
-        shots=10_000,
+        shots=1_000,
         num_trials=1,
         charlie_sizes=charlie_sizes,
         debbie_sizes=debbie_sizes,
@@ -53,7 +53,7 @@ def test_random_strategy(backend, charlie_sizes, debbie_sizes, settings):
 )
 def test_majority_vote_strategy(backend, charlie_sizes, debbie_sizes, settings):
     results = run_experiment(
-        shots=10_000,
+        shots=1_000,
         num_trials=1,
         charlie_sizes=charlie_sizes,
         debbie_sizes=debbie_sizes,


### PR DESCRIPTION
Changing this from 10k to 1k improved test time on my laptop from around 5 seconds to under 4 seconds. Is there a reason it needs to be 10k?